### PR TITLE
Added Autosync ACF Configure Option

### DIFF
--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -460,11 +460,12 @@ border-collapse: collapse;
     }
 
     public function auto_sync_acf_fields() {
-        if ( ! function_exists( 'acf_get_field_groups' ) || ! $this->isDevEnv() ) {
-            {
-                return false;
-            }
-        }
+	$autosync_acf = \Configure::read( 'autosync_acf' );
+	if ( ! function_exists( 'acf_get_field_groups' ) || ! $this->isDevEnv() || $autosync_acf === false ) {
+		{
+			return false;
+		}
+	}
 
         // vars
         $groups = acf_get_field_groups();


### PR DESCRIPTION
Autosync ACF can now be disabled if plugins like Polylang are enabled. This can be done with `Configure::write('autosync_acf', false);`