### PR TITLE
Fixed naming of images with a dynamic height (empty height-attribute …

### DIFF
--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -142,6 +142,12 @@ class Image {
         $upload_info = wp_upload_dir();
         $upload_dir  = realpath( $upload_info['basedir'] );
 
+        if ( is_numeric($options['height']) === false ) {
+            $ratio = $this->metaData['width'] / $options['width'] ;
+            $height = round($this->metaData['height'] / $ratio);
+            $options['height'] = $height;
+        }
+
         $suffix = "{$options['width']}x{$options['height']}";
 
         unset( $options['width'], $options['height'] );


### PR DESCRIPTION
…when registering the image-size).

Added if-condition to set a height while respecting the aspect-ratio, if no height was given to the image-size // naming of the sizes-array in sloth were different from the actual file-names.
Sloth was naming the images wrong if height was not set to auto or not set at all e.g. image-300x.jpg or image-300xauto.jpg
Wordpress was is naming the images with the actual height e.g. image-300x100.jpg.