### PR TITLE
loadAPIControllers: Allow slugs with underscores as seperator

### DIFF
--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -162,9 +162,9 @@ class Plugin extends \Singleton {
 
             if ( method_exists( $controller, 'single' ) ) {
                 $routes[ $route_prefix ]                               = 'index';
-                $routes[ $route_prefix . '(?:/(?P<id>[a-z0-9.-]+))?' ] = 'single';
+                $routes[ $route_prefix . '(?:/(?P<id>[a-z0-9.-_]+))?' ] = 'single';
             } else {
-                $routes[ $route_prefix . '(?:/(?P<id>[a-z0-9.-]+))?' ] = 'index';
+                $routes[ $route_prefix . '(?:/(?P<id>[a-z0-9.-_]+))?' ] = 'index';
             }
             foreach ( $routes as $route => $action ) {
                 add_action( 'rest_api_init',
@@ -316,12 +316,12 @@ border-collapse: collapse;
      .layotter-preview tr:nth-child(even),  .layotter-preview tr:nth-child(even) {
      background: #eee;
      }
-     
+
      td.media-icon img[src$=".svg"],
-     img[src$=".svg"].attachment-post-thumbnail { 
-     	width: 100% !important; height: auto !important; 
+     img[src$=".svg"].attachment-post-thumbnail {
+     	width: 100% !important; height: auto !important;
      }
-     
+
      .media-icon img[src$=".svg"] {
      	width: 60px;
      }


### PR DESCRIPTION
Allow API Slugs to contain underscores.

e.g. https://www.schumacher-visuell.de/blog/optimales_briefing_designagentur_kommunikationsagentur/
