### PR TITLE
Fixed version für spatie/image

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "org_heigl/hyphenator": "^2.2",
         "roots/wp-password-bcrypt": "^1.0",
         "spatie/emoji": "^1.0",
-        "spatie/image": "^1.5",
+        "spatie/image": "1.10.4",
         "tracy/tracy": "2.5.6",
         "twig/twig": "^1.0",
         "vlucas/phpdotenv": "^2.4"


### PR DESCRIPTION
Fixed version für spatie/image due to compatility error with spatie dependency (spatie/temporary-directory) which only allow php > 8.0

#32 